### PR TITLE
Efficient circle rendering

### DIFF
--- a/include/c2d/base.h
+++ b/include/c2d/base.h
@@ -337,6 +337,22 @@ bool C2D_DrawTriangle(
 	float x2, float y2, u32 clr2,
 	float depth);
 
+/** @brief Draws a plain line using the GPU
+ *  @param[in] x0 X coordinate of the first vertex of the line
+ *  @param[in] y0 Y coordinate of the first vertex of the line
+ *  @param[in] clr0 32-bit RGBA color of the first vertex of the line
+ *  @param[in] x1 X coordinate of the second vertex of the line
+ *  @param[in] y1 Y coordinate of the second vertex of the line
+ *  @param[in] clr1 32-bit RGBA color of the second vertex of the line
+ */
+/*static inline bool C2D_DrawLine(
+	float x0, float y0, u32 clr0,
+	float x1, float y1, u32 clr1,
+	float depth)
+{
+	return C2D_DrawTriangle(x0,y0,clr0,x0,y0,clr0,x1,y1,clr1,depth);
+}*/
+
 /** @brief Draws a plain rectangle using the GPU
  *  @param[in] x X coordinate of the top-left vertex of the rectangle
  *  @param[in] y Y coordinate of the top-left vertex of the rectangle
@@ -367,34 +383,69 @@ static inline bool C2D_DrawRectSolid(
 	return C2D_DrawRectangle(x,y,z,w,h,clr,clr,clr,clr);
 }
 
-/** @brief Draws a circle using the GPU 
- *  @param[in] x X coordinate of the top-left vertex of the circle
- *  @param[in] y Y coordinate of the top-left vertex of the circle
- *  @param[in] z Z coordinate (depth value) to draw the circle with
- *  @param[in] w Width of the circle
- *  @param[in] h Height of the circle
- *  @param[in] clr0 32-bit RGBA color of the top-left corner of the circle
- *  @param[in] clr1 32-bit RGBA color of the top-right corner of the circle
- *  @param[in] clr2 32-bit RGBA color of the bottom-left corner of the circle
- *  @param[in] clr3 32-bit RGBA color of the bottom-right corner of the circle
+/** @brief Draws an ellipse using the GPU 
+ *  @param[in] x X coordinate of the top-left vertex of the ellipse
+ *  @param[in] y Y coordinate of the top-left vertex of the ellipse
+ *  @param[in] z Z coordinate (depth value) to draw the ellipse with
+ *  @param[in] w Width of the ellipse
+ *  @param[in] h Height of the ellipse
+ *  @param[in] clr0 32-bit RGBA color of the top-left corner of the ellipse
+ *  @param[in] clr1 32-bit RGBA color of the top-right corner of the ellipse
+ *  @param[in] clr2 32-bit RGBA color of the bottom-left corner of the ellipse
+ *  @param[in] clr3 32-bit RGBA color of the bottom-right corner of the ellipse
 */
-bool C2D_DrawCircle(
+bool C2D_DrawEllipse(
 	float x, float y, float z, float w, float h, 
 	u32 clr0, u32 clr1, u32 clr2, u32 clr3);
 
-/** @brief Draws a circle using the GPU (with a solid color)
- *  @param[in] x X coordinate of the top-left vertex of the circle
- *  @param[in] y Y coordinate of the top-left vertex of the circle
- *  @param[in] z Z coordinate (depth value) to draw the circle with
- *  @param[in] w Width of the circle
- *  @param[in] h Height of the circle
- *  @param[in] clr 32-bit RGBA color of the top-left corner of the circle
+/** @brief Draws a ellipse using the GPU (with a solid color)
+ *  @param[in] x X coordinate of the top-left vertex of the ellipse
+ *  @param[in] y Y coordinate of the top-left vertex of the ellipse
+ *  @param[in] z Z coordinate (depth value) to draw the ellipse with
+ *  @param[in] w Width of the ellipse
+ *  @param[in] h Height of the ellipse
+ *  @param[in] clr 32-bit RGBA color of the ellipse
 */
-static inline bool C2D_DrawCircleSolid(
+static inline bool C2D_DrawEllipseSolid(
 	float x, float y, float z, float w, float h, 
 	u32 clr)
 {
-	return C2D_DrawCircle(x,y,z,w,h,clr,clr,clr,clr);
+	return C2D_DrawEllipse(x,y,z,w,h,clr,clr,clr,clr);
 }
 
+/** @brief Draws a circle (an ellipse with identical width and height) using the GPU
+ *  @param[in] x X coordinate of the center of the circle
+ *  @param[in] y Y coordinate of the center of the circle
+ *  @param[in] z Z coordinate (depth value) to draw the ellipse with
+ *  @param[in] radius Radius of the circle
+ *  @param[in] clr0 32-bit RGBA color of the top-left corner of the ellipse
+ *  @param[in] clr1 32-bit RGBA color of the top-right corner of the ellipse
+ *  @param[in] clr2 32-bit RGBA color of the bottom-left corner of the ellipse
+ *  @param[in] clr3 32-bit RGBA color of the bottom-right corner of the ellipse
+*/
+static inline bool C2D_DrawCircle(
+	float x, float y, float z, float radius,
+	u32 clr0, u32 clr1, u32 clr2, u32 clr3)
+{
+	return C2D_DrawEllipse(
+		x - radius,y - radius,z,radius*2,radius*2,
+		clr0,clr1,clr2,clr3);
+}
+
+/** @brief Draws a circle (an ellipse with identical width and height) using the GPU (with a solid color)
+ *  @param[in] x X coordinate of the center of the circle
+ *  @param[in] y Y coordinate of the center of the circle
+ *  @param[in] z Z coordinate (depth value) to draw the ellipse with
+ *  @param[in] radius Radius of the circle
+ *  @param[in] clr0 32-bit RGBA color of the top-left corner of the ellipse
+ *  @param[in] clr1 32-bit RGBA color of the top-right corner of the ellipse
+ *  @param[in] clr2 32-bit RGBA color of the bottom-left corner of the ellipse
+ *  @param[in] clr3 32-bit RGBA color of the bottom-right corner of the ellipse
+*/
+static inline bool C2D_DrawCircleSolid(
+	float x, float y, float z, float radius, 
+	u32 clr)
+{
+	return C2D_DrawCircle(x,y,z,radius,clr,clr,clr,clr);
+}
 /** @} */

--- a/include/c2d/base.h
+++ b/include/c2d/base.h
@@ -367,4 +367,34 @@ static inline bool C2D_DrawRectSolid(
 	return C2D_DrawRectangle(x,y,z,w,h,clr,clr,clr,clr);
 }
 
+/** @brief Draws a circle using the GPU 
+ *  @param[in] x X coordinate of the top-left vertex of the circle
+ *  @param[in] y Y coordinate of the top-left vertex of the circle
+ *  @param[in] z Z coordinate (depth value) to draw the circle with
+ *  @param[in] w Width of the circle
+ *  @param[in] h Height of the circle
+ *  @param[in] clr0 32-bit RGBA color of the top-left corner of the circle
+ *  @param[in] clr1 32-bit RGBA color of the top-right corner of the circle
+ *  @param[in] clr2 32-bit RGBA color of the bottom-left corner of the circle
+ *  @param[in] clr3 32-bit RGBA color of the bottom-right corner of the circle
+*/
+bool C2D_DrawCircle(
+	float x, float y, float z, float w, float h, 
+	u32 clr0, u32 clr1, u32 clr2, u32 clr3);
+
+/** @brief Draws a circle using the GPU (with a solid color)
+ *  @param[in] x X coordinate of the top-left vertex of the circle
+ *  @param[in] y Y coordinate of the top-left vertex of the circle
+ *  @param[in] z Z coordinate (depth value) to draw the circle with
+ *  @param[in] w Width of the circle
+ *  @param[in] h Height of the circle
+ *  @param[in] clr 32-bit RGBA color of the top-left corner of the circle
+*/
+static inline bool C2D_DrawCircleSolid(
+	float x, float y, float z, float w, float h, 
+	u32 clr)
+{
+	return C2D_DrawCircle(x,y,z,w,h,clr,clr,clr,clr);
+}
+
 /** @} */

--- a/include/c2d/base.h
+++ b/include/c2d/base.h
@@ -337,22 +337,6 @@ bool C2D_DrawTriangle(
 	float x2, float y2, u32 clr2,
 	float depth);
 
-/** @brief Draws a plain line using the GPU
- *  @param[in] x0 X coordinate of the first vertex of the line
- *  @param[in] y0 Y coordinate of the first vertex of the line
- *  @param[in] clr0 32-bit RGBA color of the first vertex of the line
- *  @param[in] x1 X coordinate of the second vertex of the line
- *  @param[in] y1 Y coordinate of the second vertex of the line
- *  @param[in] clr1 32-bit RGBA color of the second vertex of the line
- */
-/*static inline bool C2D_DrawLine(
-	float x0, float y0, u32 clr0,
-	float x1, float y1, u32 clr1,
-	float depth)
-{
-	return C2D_DrawTriangle(x0,y0,clr0,x0,y0,clr0,x1,y1,clr1,depth);
-}*/
-
 /** @brief Draws a plain rectangle using the GPU
  *  @param[in] x X coordinate of the top-left vertex of the rectangle
  *  @param[in] y Y coordinate of the top-left vertex of the rectangle

--- a/include/c2d/base.h
+++ b/include/c2d/base.h
@@ -396,7 +396,7 @@ static inline bool C2D_DrawRectSolid(
 */
 bool C2D_DrawEllipse(
 	float x, float y, float z, float w, float h, 
-	u32 clr0, u32 clr1, u32 clr2, u32 clr3);
+	u32 clr0, u32 clr1, u32 clr2, u32 clr3, bool filled C2D_OPTIONAL(true));
 
 /** @brief Draws a ellipse using the GPU (with a solid color)
  *  @param[in] x X coordinate of the top-left vertex of the ellipse
@@ -408,9 +408,9 @@ bool C2D_DrawEllipse(
 */
 static inline bool C2D_DrawEllipseSolid(
 	float x, float y, float z, float w, float h, 
-	u32 clr)
+	u32 clr, bool filled C2D_OPTIONAL(true))
 {
-	return C2D_DrawEllipse(x,y,z,w,h,clr,clr,clr,clr);
+	return C2D_DrawEllipse(x,y,z,w,h,clr,clr,clr,clr,filled);
 }
 
 /** @brief Draws a circle (an ellipse with identical width and height) using the GPU
@@ -425,11 +425,12 @@ static inline bool C2D_DrawEllipseSolid(
 */
 static inline bool C2D_DrawCircle(
 	float x, float y, float z, float radius,
-	u32 clr0, u32 clr1, u32 clr2, u32 clr3)
+	u32 clr0, u32 clr1, u32 clr2, u32 clr3,
+	bool filled C2D_OPTIONAL(true))
 {
 	return C2D_DrawEllipse(
 		x - radius,y - radius,z,radius*2,radius*2,
-		clr0,clr1,clr2,clr3);
+		clr0,clr1,clr2,clr3,filled);
 }
 
 /** @brief Draws a circle (an ellipse with identical width and height) using the GPU (with a solid color)
@@ -444,8 +445,8 @@ static inline bool C2D_DrawCircle(
 */
 static inline bool C2D_DrawCircleSolid(
 	float x, float y, float z, float radius, 
-	u32 clr)
+	u32 clr, bool filled C2D_OPTIONAL(true))
 {
-	return C2D_DrawCircle(x,y,z,radius,clr,clr,clr,clr);
+	return C2D_DrawCircle(x,y,z,radius,clr,clr,clr,clr,filled);
 }
 /** @} */

--- a/include/c2d/base.h
+++ b/include/c2d/base.h
@@ -396,7 +396,7 @@ static inline bool C2D_DrawRectSolid(
 */
 bool C2D_DrawEllipse(
 	float x, float y, float z, float w, float h, 
-	u32 clr0, u32 clr1, u32 clr2, u32 clr3, bool filled C2D_OPTIONAL(true));
+	u32 clr0, u32 clr1, u32 clr2, u32 clr3);
 
 /** @brief Draws a ellipse using the GPU (with a solid color)
  *  @param[in] x X coordinate of the top-left vertex of the ellipse
@@ -408,9 +408,9 @@ bool C2D_DrawEllipse(
 */
 static inline bool C2D_DrawEllipseSolid(
 	float x, float y, float z, float w, float h, 
-	u32 clr, bool filled C2D_OPTIONAL(true))
+	u32 clr)
 {
-	return C2D_DrawEllipse(x,y,z,w,h,clr,clr,clr,clr,filled);
+	return C2D_DrawEllipse(x,y,z,w,h,clr,clr,clr,clr);
 }
 
 /** @brief Draws a circle (an ellipse with identical width and height) using the GPU
@@ -425,12 +425,11 @@ static inline bool C2D_DrawEllipseSolid(
 */
 static inline bool C2D_DrawCircle(
 	float x, float y, float z, float radius,
-	u32 clr0, u32 clr1, u32 clr2, u32 clr3,
-	bool filled C2D_OPTIONAL(true))
+	u32 clr0, u32 clr1, u32 clr2, u32 clr3)
 {
 	return C2D_DrawEllipse(
 		x - radius,y - radius,z,radius*2,radius*2,
-		clr0,clr1,clr2,clr3,filled);
+		clr0,clr1,clr2,clr3);
 }
 
 /** @brief Draws a circle (an ellipse with identical width and height) using the GPU (with a solid color)
@@ -445,8 +444,8 @@ static inline bool C2D_DrawCircle(
 */
 static inline bool C2D_DrawCircleSolid(
 	float x, float y, float z, float radius, 
-	u32 clr, bool filled C2D_OPTIONAL(true))
+	u32 clr)
 {
-	return C2D_DrawCircle(x,y,z,radius,clr,clr,clr,clr,filled);
+	return C2D_DrawCircle(x,y,z,radius,clr,clr,clr,clr);
 }
 /** @} */

--- a/include/c2d/base.h
+++ b/include/c2d/base.h
@@ -377,6 +377,7 @@ static inline bool C2D_DrawRectSolid(
  *  @param[in] clr1 32-bit RGBA color of the top-right corner of the ellipse
  *  @param[in] clr2 32-bit RGBA color of the bottom-left corner of the ellipse
  *  @param[in] clr3 32-bit RGBA color of the bottom-right corner of the ellipse
+ *  @note Switching to and from "circle mode" internally requires an expensive state change. As such, the recommended usage of this feature is to draw all non-circular objects first, then draw all circular objects.
 */
 bool C2D_DrawEllipse(
 	float x, float y, float z, float w, float h, 
@@ -389,6 +390,7 @@ bool C2D_DrawEllipse(
  *  @param[in] w Width of the ellipse
  *  @param[in] h Height of the ellipse
  *  @param[in] clr 32-bit RGBA color of the ellipse
+ *  @note Switching to and from "circle mode" internally requires an expensive state change. As such, the recommended usage of this feature is to draw all non-circular objects first, then draw all circular objects.
 */
 static inline bool C2D_DrawEllipseSolid(
 	float x, float y, float z, float w, float h, 
@@ -406,6 +408,7 @@ static inline bool C2D_DrawEllipseSolid(
  *  @param[in] clr1 32-bit RGBA color of the top-right corner of the ellipse
  *  @param[in] clr2 32-bit RGBA color of the bottom-left corner of the ellipse
  *  @param[in] clr3 32-bit RGBA color of the bottom-right corner of the ellipse
+ *  @note Switching to and from "circle mode" internally requires an expensive state change. As such, the recommended usage of this feature is to draw all non-circular objects first, then draw all circular objects.
 */
 static inline bool C2D_DrawCircle(
 	float x, float y, float z, float radius,
@@ -425,6 +428,7 @@ static inline bool C2D_DrawCircle(
  *  @param[in] clr1 32-bit RGBA color of the top-right corner of the ellipse
  *  @param[in] clr2 32-bit RGBA color of the bottom-left corner of the ellipse
  *  @param[in] clr3 32-bit RGBA color of the bottom-right corner of the ellipse
+ *  @note Switching to and from "circle mode" internally requires an expensive state change. As such, the recommended usage of this feature is to draw all non-circular objects first, then draw all circular objects.
 */
 static inline bool C2D_DrawCircleSolid(
 	float x, float y, float z, float radius, 

--- a/source/base.c
+++ b/source/base.c
@@ -80,6 +80,7 @@ bool C2D_Init(size_t maxObjects)
 	Mtx_Identity(&ctx->mdlvMtx);
 	ctx->fadeClr = 0;
 
+	C3D_FrameEndHook(C2Di_FrameEndHook, NULL);
 	return true;
 }
 
@@ -148,9 +149,6 @@ void C2D_Prepare(void)
 
 	// Don't cull anything
 	C3D_CullFace(GPU_CULL_NONE);
-
-	// Set the frame end hook
-	C3D_FrameEndHook(C2Di_FrameEndHook, NULL);
 }
 
 void C2D_Flush(void)

--- a/source/base.c
+++ b/source/base.c
@@ -62,7 +62,6 @@ bool C2D_Init(size_t maxObjects)
 	C3D_ProcTexCombiner(&ctx->ptCircle, true, GPU_PT_SQRT2, GPU_PT_SQRT2);
 	C3D_ProcTexFilter(&ctx->ptCircle, GPU_PT_LINEAR);
 
-
 	// Prepare proctex lut
 	float data[129];
 	int i;
@@ -81,7 +80,6 @@ bool C2D_Init(size_t maxObjects)
 	Mtx_Identity(&ctx->mdlvMtx);
 	ctx->fadeClr = 0;
 
-	C3D_FrameEndHook(C2Di_FrameEndHook, NULL);
 	return true;
 }
 
@@ -150,6 +148,9 @@ void C2D_Prepare(void)
 
 	// Don't cull anything
 	C3D_CullFace(GPU_CULL_NONE);
+
+	// Set the frame end hook
+	C3D_FrameEndHook(C2Di_FrameEndHook, NULL);
 }
 
 void C2D_Flush(void)
@@ -285,7 +286,6 @@ bool C2D_DrawImage(C2D_Image img, const C2D_DrawParams* params, const C2D_ImageT
 		return false;
 
 	C2Di_SetCircle(false);
-
 	C2Di_SetTex(img.tex);
 	C2Di_Update();
 
@@ -340,7 +340,6 @@ bool C2D_DrawTriangle(float x0, float y0, u32 clr0, float x1, float y1, u32 clr1
 		return false;
 
 	C2Di_SetCircle(false);
-
 	// Not necessary:
 	//C2Di_SetSrc(C2DiF_Src_None);
 	C2Di_Update();
@@ -360,7 +359,6 @@ bool C2D_DrawRectangle(float x, float y, float z, float w, float h, u32 clr0, u3
 		return false;
 
 	C2Di_SetCircle(false);
-
 	// Not necessary:
 	//C2Di_SetSrc(C2DiF_Src_None);
 	C2Di_Update();
@@ -384,7 +382,6 @@ bool C2D_DrawEllipse(float x, float y, float z, float w, float h, u32 clr0, u32 
 		return false;
 
 	C2Di_SetCircle(true);
-
 	// Not necessary:
 	//C2Di_SetSrc(C2DiF_Src_None);
 	C2Di_Update();
@@ -443,18 +440,18 @@ void C2Di_Update(void)
 
 	if (flags & C2DiF_DirtyProcTex)
 	{	
-		if (ctx->flags & C2DiF_ProcTex_Circle) //flags variable is only for dirty flags
+		if (ctx->flags & C2DiF_ProcTex_Circle) // flags variable is only for dirty flags
 		{
 			C3D_ProcTexBind(1, &ctx->ptCircle);
 			C3D_ProcTexLutBind(GPU_LUT_ALPHAMAP, &ctx->ptCircleLut);
 			
-			//Set TexEnv1 to use proctex to generate a circle.
-			//This circle then either passes through the alpha (if the fragment
-			//is within the circle) or discards the fragment.
-			//Unfortunately, blending the vertex color is not possible
-			//(because proctex is already being used), therefore it is simply multiplied.
-			//texenv1.rgb = texenv0.rgb * vtx.color.rgb;
-			//texenv1.a = texenv0.rgb * proctex.a;
+			// Set TexEnv1 to use proctex to generate a circle.
+			// This circle then either passes through the alpha (if the fragment
+			// is within the circle) or discards the fragment.
+			// Unfortunately, blending the vertex color is not possible
+			// (because proctex is already being used), therefore it is simply multiplied.
+			// texenv1.rgb = texenv0.rgb * vtx.color.rgb;
+			// texenv1.a = texenv0.rgb * proctex.a;
 			C3D_TexEnv* env = C3D_GetTexEnv(1);
 			C3D_TexEnvInit(env);
 			C3D_TexEnvSrc(env, C3D_RGB, GPU_PREVIOUS, GPU_PRIMARY_COLOR, 0);

--- a/source/base.c
+++ b/source/base.c
@@ -73,6 +73,10 @@ bool C2D_Init(size_t maxObjects)
 		data[i] = (i >= 127) ? 0 : 1;
 	ProcTexLut_FromArray(&ctx->ptCircleLut, data);
 
+	for (i = 0; i <= 128; i ++)
+		data[i] = (i == 126 || i == 125 || i == 124) ? 1 : 0;
+	ProcTexLut_FromArray(&ctx->ptCircleUnfilledLut, data);
+
 	ctx->flags = C2DiF_Active;
 	ctx->vtxBufPos = 0;
 	ctx->vtxBufLastPos = 0;
@@ -285,7 +289,7 @@ bool C2D_DrawImage(C2D_Image img, const C2D_DrawParams* params, const C2D_ImageT
 	if (6 > (ctx->vtxBufSize - ctx->vtxBufPos))
 		return false;
 
-	C2Di_SetCircle(false);
+	C2Di_SetProcTexMode(C2DiF_ProcTex_Color_Interpolate);
 	C2Di_SetTex(img.tex);
 	C2Di_Update();
 
@@ -339,7 +343,7 @@ bool C2D_DrawTriangle(float x0, float y0, u32 clr0, float x1, float y1, u32 clr1
 	if (3 > (ctx->vtxBufSize - ctx->vtxBufPos))
 		return false;
 
-	C2Di_SetCircle(false);
+	C2Di_SetProcTexMode(C2DiF_ProcTex_Color_Interpolate);
 	// Not necessary:
 	//C2Di_SetSrc(C2DiF_Src_None);
 	C2Di_Update();
@@ -358,7 +362,7 @@ bool C2D_DrawRectangle(float x, float y, float z, float w, float h, u32 clr0, u3
 	if (6 > (ctx->vtxBufSize - ctx->vtxBufPos))
 		return false;
 
-	C2Di_SetCircle(false);
+	C2Di_SetProcTexMode(C2DiF_ProcTex_Color_Interpolate);
 	// Not necessary:
 	//C2Di_SetSrc(C2DiF_Src_None);
 	C2Di_Update();
@@ -373,7 +377,7 @@ bool C2D_DrawRectangle(float x, float y, float z, float w, float h, u32 clr0, u3
 	return true;
 }
 
-bool C2D_DrawEllipse(float x, float y, float z, float w, float h, u32 clr0, u32 clr1, u32 clr2, u32 clr3)
+bool C2D_DrawEllipse(float x, float y, float z, float w, float h, u32 clr0, u32 clr1, u32 clr2, u32 clr3, bool filled)
 {
 	C2Di_Context* ctx = C2Di_GetContext();
 	if (!(ctx->flags & C2DiF_Active))
@@ -381,7 +385,7 @@ bool C2D_DrawEllipse(float x, float y, float z, float w, float h, u32 clr0, u32 
 	if (6 > (ctx->vtxBufSize - ctx->vtxBufPos))
 		return false;
 
-	C2Di_SetCircle(true);
+	C2Di_SetProcTexMode(filled ? C2DiF_ProcTex_Circle : C2DiF_ProcTex_Circle_Unfilled);
 	// Not necessary:
 	//C2Di_SetSrc(C2DiF_Src_None);
 	C2Di_Update();
@@ -440,7 +444,7 @@ void C2Di_Update(void)
 
 	if (flags & C2DiF_DirtyProcTex)
 	{	
-		if (ctx->flags & C2DiF_ProcTex_Circle) // flags variable is only for dirty flags
+		if (ctx->ptmode == C2DiF_ProcTex_Circle)
 		{
 			C3D_ProcTexBind(1, &ctx->ptCircle);
 			C3D_ProcTexLutBind(GPU_LUT_ALPHAMAP, &ctx->ptCircleLut);
@@ -448,6 +452,26 @@ void C2Di_Update(void)
 			// Set TexEnv1 to use proctex to generate a circle.
 			// This circle then either passes through the alpha (if the fragment
 			// is within the circle) or discards the fragment.
+			// Unfortunately, blending the vertex color is not possible
+			// (because proctex is already being used), therefore it is simply multiplied.
+			// texenv1.rgb = texenv0.rgb * vtx.color.rgb;
+			// texenv1.a = texenv0.rgb * proctex.a;
+			C3D_TexEnv* env = C3D_GetTexEnv(1);
+			C3D_TexEnvInit(env);
+			C3D_TexEnvSrc(env, C3D_RGB, GPU_PREVIOUS, GPU_PRIMARY_COLOR, 0);
+			C3D_TexEnvSrc(env, C3D_Alpha, GPU_PREVIOUS, GPU_TEXTURE3, 0);
+			C3D_TexEnvFunc(env, C3D_Both, GPU_MODULATE);
+		}
+		else if (ctx->ptmode == C2DiF_ProcTex_Circle_Unfilled)
+		{
+			// Same code as above, but, the LUT is set differently-
+			// it is now configured to pass through the outer edge of the circle.
+			C3D_ProcTexBind(1, &ctx->ptCircle);
+			C3D_ProcTexLutBind(GPU_LUT_ALPHAMAP, &ctx->ptCircleUnfilledLut);
+			
+			// Set TexEnv1 to use proctex to generate a circle.
+			// This circle then either passes through the alpha (if the fragment
+			// is within the rim of the circle) or discards the fragment.
 			// Unfortunately, blending the vertex color is not possible
 			// (because proctex is already being used), therefore it is simply multiplied.
 			// texenv1.rgb = texenv0.rgb * vtx.color.rgb;

--- a/source/base.c
+++ b/source/base.c
@@ -375,7 +375,7 @@ bool C2D_DrawRectangle(float x, float y, float z, float w, float h, u32 clr0, u3
 	return true;
 }
 
-bool C2D_DrawCircle(float x, float y, float z, float w, float h, u32 clr0, u32 clr1, u32 clr2, u32 clr3)
+bool C2D_DrawEllipse(float x, float y, float z, float w, float h, u32 clr0, u32 clr1, u32 clr2, u32 clr3)
 {
 	C2Di_Context* ctx = C2Di_GetContext();
 	if (!(ctx->flags & C2DiF_Active))

--- a/source/internal.h
+++ b/source/internal.h
@@ -85,7 +85,7 @@ static inline void C2Di_SetCircle(bool iscircle)
 		ctx->flags |= C2DiF_DirtyProcTex;
 		ctx->flags |= C2DiF_ProcTex_Circle;
 	}
-	else if(ctx->flags & C2DiF_ProcTex_Circle)
+	else if(!iscircle && ctx->flags & C2DiF_ProcTex_Circle)
 	{
 		ctx->flags |= C2DiF_DirtyProcTex;
 		ctx->flags &= ~C2DiF_ProcTex_Circle;

--- a/source/internal.h
+++ b/source/internal.h
@@ -19,7 +19,6 @@ typedef struct
 	C3D_ProcTex ptCircle;
 	C3D_ProcTexLut ptBlendLut;
 	C3D_ProcTexLut ptCircleLut;
-	C3D_ProcTexLut ptCircleUnfilledLut;
 	u32 sceneW, sceneH;
 
 	C2Di_Vertex* vtxBuf;
@@ -28,7 +27,6 @@ typedef struct
 	size_t vtxBufLastPos;
 
 	u32 flags;
-	u32 ptmode;
 	C3D_Mtx projMtx;
 	C3D_Mtx mdlvMtx;
 	C3D_Tex* curTex;
@@ -49,14 +47,9 @@ enum
 	C2DiF_Src_Tex   = BIT(31),
 	C2DiF_Src_Mask  = BIT(31),
 
-	C2DiF_DirtyAny = C2DiF_DirtyProj | C2DiF_DirtyMdlv | C2DiF_DirtyTex | C2DiF_DirtySrc | C2DiF_DirtyFade | C2DiF_DirtyProcTex,
-};
+	C2DiF_ProcTex_Circle = BIT(30),
 
-enum
-{
-	C2DiF_ProcTex_Color_Interpolate = 0,
-	C2DiF_ProcTex_Circle = 1,
-	C2DiF_ProcTex_Circle_Unfilled = 2,
+	C2DiF_DirtyAny = C2DiF_DirtyProj | C2DiF_DirtyMdlv | C2DiF_DirtyTex | C2DiF_DirtySrc | C2DiF_DirtyFade | C2DiF_DirtyProcTex,
 };
 
 static inline C2Di_Context* C2Di_GetContext(void)
@@ -84,38 +77,18 @@ static inline void C2Di_SetTex(C3D_Tex* tex)
 	}
 }
 
-static inline void C2Di_SetProcTexMode(u32 proctexmode)
+static inline void C2Di_SetCircle(bool iscircle)
 {
 	C2Di_Context* ctx = C2Di_GetContext();
-	switch(proctexmode)
+	if(iscircle && !(ctx->flags & C2DiF_ProcTex_Circle))
 	{
-		case C2DiF_ProcTex_Circle:
-		{
-			if(ctx->ptmode != C2DiF_ProcTex_Circle)
-			{
-				ctx->flags |= C2DiF_DirtyProcTex;
-				ctx->ptmode = C2DiF_ProcTex_Circle;
-			}
-			break;
-		}
-		case C2DiF_ProcTex_Circle_Unfilled:
-		{
-			if(ctx->ptmode != C2DiF_ProcTex_Circle_Unfilled)
-			{
-				ctx->flags |= C2DiF_DirtyProcTex;
-				ctx->ptmode = C2DiF_ProcTex_Circle_Unfilled;
-			}
-			break;
-		}
-		case C2DiF_ProcTex_Color_Interpolate:
-		{
-			if(ctx->ptmode != C2DiF_ProcTex_Color_Interpolate)
-			{
-				ctx->flags |= C2DiF_DirtyProcTex;
-				ctx->ptmode = C2DiF_ProcTex_Color_Interpolate;
-			}
-			break;
-		}
+		ctx->flags |= C2DiF_DirtyProcTex;
+		ctx->flags |= C2DiF_ProcTex_Circle;
+	}
+	else if(!iscircle && ctx->flags & C2DiF_ProcTex_Circle)
+	{
+		ctx->flags |= C2DiF_DirtyProcTex;
+		ctx->flags &= ~C2DiF_ProcTex_Circle;
 	}
 
 }

--- a/source/internal.h
+++ b/source/internal.h
@@ -5,7 +5,7 @@ typedef struct
 {
 	float pos[3];
 	float texcoord[2];
-	float blend[2];
+	float ptcoord[2];
 	u32 color;
 } C2Di_Vertex;
 
@@ -16,7 +16,9 @@ typedef struct
 	C3D_AttrInfo attrInfo;
 	C3D_BufInfo bufInfo;
 	C3D_ProcTex ptBlend;
+	C3D_ProcTex ptCircle;
 	C3D_ProcTexLut ptBlendLut;
+	C3D_ProcTexLut ptCircleLut;
 	u32 sceneW, sceneH;
 
 	C2Di_Vertex* vtxBuf;
@@ -33,18 +35,21 @@ typedef struct
 
 enum
 {
-	C2DiF_Active    = BIT(0),
-	C2DiF_DirtyProj = BIT(1),
-	C2DiF_DirtyMdlv = BIT(2),
-	C2DiF_DirtyTex  = BIT(3),
-	C2DiF_DirtySrc  = BIT(4),
-	C2DiF_DirtyFade = BIT(5),
+	C2DiF_Active       = BIT(0),
+	C2DiF_DirtyProj    = BIT(1),
+	C2DiF_DirtyMdlv    = BIT(2),
+	C2DiF_DirtyTex     = BIT(3),
+	C2DiF_DirtySrc     = BIT(4),
+	C2DiF_DirtyFade    = BIT(5),
+	C2DiF_DirtyProcTex = BIT(6),
 
 	C2DiF_Src_None  = 0,
 	C2DiF_Src_Tex   = BIT(31),
 	C2DiF_Src_Mask  = BIT(31),
 
-	C2DiF_DirtyAny = C2DiF_DirtyProj | C2DiF_DirtyMdlv | C2DiF_DirtyTex | C2DiF_DirtySrc | C2DiF_DirtyFade,
+	C2DiF_ProcTex_Circle = BIT(30),
+
+	C2DiF_DirtyAny = C2DiF_DirtyProj | C2DiF_DirtyMdlv | C2DiF_DirtyTex | C2DiF_DirtySrc | C2DiF_DirtyFade | C2DiF_DirtyProcTex,
 };
 
 static inline C2Di_Context* C2Di_GetContext(void)
@@ -72,6 +77,22 @@ static inline void C2Di_SetTex(C3D_Tex* tex)
 	}
 }
 
+static inline void C2Di_SetCircle(bool iscircle)
+{
+	C2Di_Context* ctx = C2Di_GetContext();
+	if(iscircle && !(ctx->flags & C2DiF_ProcTex_Circle))
+	{
+		ctx->flags |= C2DiF_DirtyProcTex;
+		ctx->flags |= C2DiF_ProcTex_Circle;
+	}
+	else if(ctx->flags & C2DiF_ProcTex_Circle)
+	{
+		ctx->flags |= C2DiF_DirtyProcTex;
+		ctx->flags &= ~C2DiF_ProcTex_Circle;
+	}
+
+}
+
 typedef struct
 {
 	float topLeft[2];
@@ -81,6 +102,6 @@ typedef struct
 } C2Di_Quad;
 
 void C2Di_CalcQuad(C2Di_Quad* quad, const C2D_DrawParams* params);
-void C2Di_AppendVtx(float x, float y, float z, float u, float v, float blend, u32 color);
+void C2Di_AppendVtx(float x, float y, float z, float u, float v, float ptx, float pty, u32 color);
 void C2Di_FlushVtxBuf(void);
 void C2Di_Update(void);

--- a/source/internal.h
+++ b/source/internal.h
@@ -19,6 +19,7 @@ typedef struct
 	C3D_ProcTex ptCircle;
 	C3D_ProcTexLut ptBlendLut;
 	C3D_ProcTexLut ptCircleLut;
+	C3D_ProcTexLut ptCircleUnfilledLut;
 	u32 sceneW, sceneH;
 
 	C2Di_Vertex* vtxBuf;
@@ -27,6 +28,7 @@ typedef struct
 	size_t vtxBufLastPos;
 
 	u32 flags;
+	u32 ptmode;
 	C3D_Mtx projMtx;
 	C3D_Mtx mdlvMtx;
 	C3D_Tex* curTex;
@@ -47,9 +49,14 @@ enum
 	C2DiF_Src_Tex   = BIT(31),
 	C2DiF_Src_Mask  = BIT(31),
 
-	C2DiF_ProcTex_Circle = BIT(30),
-
 	C2DiF_DirtyAny = C2DiF_DirtyProj | C2DiF_DirtyMdlv | C2DiF_DirtyTex | C2DiF_DirtySrc | C2DiF_DirtyFade | C2DiF_DirtyProcTex,
+};
+
+enum
+{
+	C2DiF_ProcTex_Color_Interpolate = 0,
+	C2DiF_ProcTex_Circle = 1,
+	C2DiF_ProcTex_Circle_Unfilled = 2,
 };
 
 static inline C2Di_Context* C2Di_GetContext(void)
@@ -77,18 +84,38 @@ static inline void C2Di_SetTex(C3D_Tex* tex)
 	}
 }
 
-static inline void C2Di_SetCircle(bool iscircle)
+static inline void C2Di_SetProcTexMode(u32 proctexmode)
 {
 	C2Di_Context* ctx = C2Di_GetContext();
-	if(iscircle && !(ctx->flags & C2DiF_ProcTex_Circle))
+	switch(proctexmode)
 	{
-		ctx->flags |= C2DiF_DirtyProcTex;
-		ctx->flags |= C2DiF_ProcTex_Circle;
-	}
-	else if(!iscircle && ctx->flags & C2DiF_ProcTex_Circle)
-	{
-		ctx->flags |= C2DiF_DirtyProcTex;
-		ctx->flags &= ~C2DiF_ProcTex_Circle;
+		case C2DiF_ProcTex_Circle:
+		{
+			if(ctx->ptmode != C2DiF_ProcTex_Circle)
+			{
+				ctx->flags |= C2DiF_DirtyProcTex;
+				ctx->ptmode = C2DiF_ProcTex_Circle;
+			}
+			break;
+		}
+		case C2DiF_ProcTex_Circle_Unfilled:
+		{
+			if(ctx->ptmode != C2DiF_ProcTex_Circle_Unfilled)
+			{
+				ctx->flags |= C2DiF_DirtyProcTex;
+				ctx->ptmode = C2DiF_ProcTex_Circle_Unfilled;
+			}
+			break;
+		}
+		case C2DiF_ProcTex_Color_Interpolate:
+		{
+			if(ctx->ptmode != C2DiF_ProcTex_Color_Interpolate)
+			{
+				ctx->flags |= C2DiF_DirtyProcTex;
+				ctx->ptmode = C2DiF_ProcTex_Color_Interpolate;
+			}
+			break;
+		}
 	}
 
 }

--- a/source/internal.h
+++ b/source/internal.h
@@ -80,12 +80,12 @@ static inline void C2Di_SetTex(C3D_Tex* tex)
 static inline void C2Di_SetCircle(bool iscircle)
 {
 	C2Di_Context* ctx = C2Di_GetContext();
-	if(iscircle && !(ctx->flags & C2DiF_ProcTex_Circle))
+	if (iscircle && !(ctx->flags & C2DiF_ProcTex_Circle))
 	{
 		ctx->flags |= C2DiF_DirtyProcTex;
 		ctx->flags |= C2DiF_ProcTex_Circle;
 	}
-	else if(!iscircle && ctx->flags & C2DiF_ProcTex_Circle)
+	else if (!iscircle && (ctx->flags & C2DiF_ProcTex_Circle))
 	{
 		ctx->flags |= C2DiF_DirtyProcTex;
 		ctx->flags &= ~C2DiF_ProcTex_Circle;

--- a/source/render2d.v.pica
+++ b/source/render2d.v.pica
@@ -14,13 +14,14 @@
 .out oPosition  position
 .out oTexCoord0 texcoord0
 .out oTexCoord1 texcoord1
+.out oTexCoord2 texcoord2
 .out oColor     color
 
 ; Inputs
-.in iPosition v0
-.in iTexCoord v1
-.in iBlend    v2
-.in iColor    v3
+.in iPosition      v0
+.in iTexCoord      v1
+.in iProcTexCoord  v2
+.in iColor         v3
 
 ; Main procedure
 .entry render2d_main
@@ -45,7 +46,7 @@
 	mov oTexCoord0, iTexCoord
 
 	; oTexCoord1 = iBlend
-	mov oTexCoord1, iBlend
+	mov oTexCoord1, iProcTexCoord
 
 	; oColor = iColor / 255
 	mul oColor, clrdiv, iColor

--- a/source/render2d.v.pica
+++ b/source/render2d.v.pica
@@ -14,7 +14,6 @@
 .out oPosition  position
 .out oTexCoord0 texcoord0
 .out oTexCoord1 texcoord1
-.out oTexCoord2 texcoord2
 .out oColor     color
 
 ; Inputs

--- a/source/text.c
+++ b/source/text.c
@@ -216,7 +216,7 @@ void C2D_DrawText(const C2D_Text* text, u32 flags, float x, float y, float z, fl
 
 	va_end(va);
 
-	C2Di_SetCircle(false);
+	C2Di_SetProcTexMode(C2DiF_ProcTex_Color_Interpolate);
 
 	for (cur = begin; cur != end; ++cur)
 	{

--- a/source/text.c
+++ b/source/text.c
@@ -216,6 +216,8 @@ void C2D_DrawText(const C2D_Text* text, u32 flags, float x, float y, float z, fl
 
 	va_end(va);
 
+	C2Di_SetCircle(false);
+
 	for (cur = begin; cur != end; ++cur)
 	{
 		float glyphW = scaleX*cur->width;
@@ -224,11 +226,11 @@ void C2D_DrawText(const C2D_Text* text, u32 flags, float x, float y, float z, fl
 
 		C2Di_SetTex(cur->sheet);
 		C2Di_Update();
-		C2Di_AppendVtx(glyphX,        glyphY,        glyphZ, cur->texcoord.left,  cur->texcoord.top,    1.0f, color);
-		C2Di_AppendVtx(glyphX,        glyphY+glyphH, glyphZ, cur->texcoord.left,  cur->texcoord.bottom, 1.0f, color);
-		C2Di_AppendVtx(glyphX+glyphW, glyphY,        glyphZ, cur->texcoord.right, cur->texcoord.top,    1.0f, color);
-		C2Di_AppendVtx(glyphX+glyphW, glyphY,        glyphZ, cur->texcoord.right, cur->texcoord.top,    1.0f, color);
-		C2Di_AppendVtx(glyphX,        glyphY+glyphH, glyphZ, cur->texcoord.left,  cur->texcoord.bottom, 1.0f, color);
-		C2Di_AppendVtx(glyphX+glyphW, glyphY+glyphH, glyphZ, cur->texcoord.right, cur->texcoord.bottom, 1.0f, color);
+		C2Di_AppendVtx(glyphX,        glyphY,        glyphZ, cur->texcoord.left,  cur->texcoord.top,    0.0f, 1.0f, color);
+		C2Di_AppendVtx(glyphX,        glyphY+glyphH, glyphZ, cur->texcoord.left,  cur->texcoord.bottom, 0.0f, 1.0f, color);
+		C2Di_AppendVtx(glyphX+glyphW, glyphY,        glyphZ, cur->texcoord.right, cur->texcoord.top,    0.0f, 1.0f, color);
+		C2Di_AppendVtx(glyphX+glyphW, glyphY,        glyphZ, cur->texcoord.right, cur->texcoord.top,    0.0f, 1.0f, color);
+		C2Di_AppendVtx(glyphX,        glyphY+glyphH, glyphZ, cur->texcoord.left,  cur->texcoord.bottom, 0.0f, 1.0f, color);
+		C2Di_AppendVtx(glyphX+glyphW, glyphY+glyphH, glyphZ, cur->texcoord.right, cur->texcoord.bottom, 0.0f, 1.0f, color);
 	}
 }

--- a/source/text.c
+++ b/source/text.c
@@ -216,7 +216,7 @@ void C2D_DrawText(const C2D_Text* text, u32 flags, float x, float y, float z, fl
 
 	va_end(va);
 
-	C2Di_SetProcTexMode(C2DiF_ProcTex_Color_Interpolate);
+	C2Di_SetCircle(false);
 
 	for (cur = begin; cur != end; ++cur)
 	{


### PR DESCRIPTION
Although GPUs are not built for rendering circles, the PICA200's proctex functionality provides the hardware functionality to fake one perfectly in 2D.
This commit adds a bit of internal logic to switch between different proctex setups- the existing one, to blend between the texture and the primary color, and the new one, used to generate a circle.
This circle is generated using proctex's ADDSQRT2 function and using GPU_MIRRORED_REPEAT as the clamping operation. Because ADDSQRT2 has the property of emitting a quarter of a circle, mirroring/repeating it can emit a full circle. The alpha lookup table can then be configured to have full alpha within the circle, and no alpha outside of the circle. Multiplying this alpha value with the current alpha in TexEnv discards any fragments not within the circle.
This is far, far superior to the current scenario in which people go around spamming vertices for triangles to fill in a circle. I've seen plenty of people doing such a stupid move without understanding the problems with it or why it's a bad idea, which is *exactly* what citro2d was built to prevent. This garbage code originates all the way back in sf2d(!), and the more we remove that kind of code from the ecosystem the better off everyone is.