### PR TITLE
Fixed an incorrect docstring

### DIFF
--- a/include/c2d/base.h
+++ b/include/c2d/base.h
@@ -483,10 +483,7 @@ static inline bool C2D_DrawCircle(
  *  @param[in] y Y coordinate of the center of the circle
  *  @param[in] z Z coordinate (depth value) to draw the ellipse with
  *  @param[in] radius Radius of the circle
- *  @param[in] clr0 32-bit RGBA color of the top-left corner of the ellipse
- *  @param[in] clr1 32-bit RGBA color of the top-right corner of the ellipse
- *  @param[in] clr2 32-bit RGBA color of the bottom-left corner of the ellipse
- *  @param[in] clr3 32-bit RGBA color of the bottom-right corner of the ellipse
+ *  @param[in] clr 32-bit RGBA color of the ellipse
  *  @note Switching to and from "circle mode" internally requires an expensive state change. As such, the recommended usage of this feature is to draw all non-circular objects first, then draw all circular objects.
 */
 static inline bool C2D_DrawCircleSolid(


### PR DESCRIPTION
`C2D_DrawCircleSolid`'s documentation specifies 4 color parameter when the function actually only takes one. It's really just a small documentation copypaste mistake and has no effect on the code, but since I spotted it I thought I might as well correct it :)