### PR TITLE
C2D_Font: Add Filter Mode Configuration

### DIFF
--- a/include/c2d/font.h
+++ b/include/c2d/font.h
@@ -54,6 +54,13 @@ C2D_Font C2D_FontLoadSystem(CFG_Region region);
  */
 void C2D_FontFree(C2D_Font font);
 
+/** @brief Set a font's texture filter
+ * @param[in] font Font handle
+ * @param[in] magFilter the magnification filter
+ * @param[in] minFilter the minification filter
+ */
+void C2D_FontSetFilter(C2D_Font font, GPU_TEXTURE_FILTER_PARAM magFilter, GPU_TEXTURE_FILTER_PARAM minFilter);
+
 /** @brief Find the glyph index of a codepoint, or returns the default
  * @param[in] font Font to search, or NULL for system font
  * @param[in] codepoint Codepoint to search for

--- a/source/font.c
+++ b/source/font.c
@@ -46,8 +46,8 @@ static C2D_Font C2Di_PostLoadFont(C2D_Font font)
 			tex->size = glyphInfo->sheetSize;
 			tex->width = glyphInfo->sheetWidth;
 			tex->height = glyphInfo->sheetHeight;
-			tex->param = GPU_TEXTURE_MAG_FILTER(GPU_LINEAR) | GPU_TEXTURE_MIN_FILTER(GPU_LINEAR)
-				| GPU_TEXTURE_WRAP_S(GPU_CLAMP_TO_BORDER) | GPU_TEXTURE_WRAP_T(GPU_CLAMP_TO_BORDER);
+			tex->param = font.magFilter | font.minFilter | GPU_TEXTURE_WRAP_S(GPU_CLAMP_TO_BORDER) |
+						 GPU_TEXTURE_WRAP_T(GPU_CLAMP_TO_BORDER);
 			tex->border = 0xFFFFFFFF;
 			tex->lodParam = 0;
 		}
@@ -202,6 +202,12 @@ void C2D_FontFree(C2D_Font font)
 			linearFree(font->cfnt);
 		free(font->glyphSheets);
 	}
+}
+
+void C2D_FontSetFilter(C2D_Font font, GPU_TEXTURE_FILTER_PARAM magFilter, GPU_TEXTURE_FILTER_PARAM minFilter)
+{
+	font.magFilter = magFilter;
+	font.minFilter = minFilter;
 }
 
 int C2D_FontGlyphIndexFromCodePoint(C2D_Font font, u32 codepoint)

--- a/source/font.c
+++ b/source/font.c
@@ -46,8 +46,8 @@ static C2D_Font C2Di_PostLoadFont(C2D_Font font)
 			tex->size = glyphInfo->sheetSize;
 			tex->width = glyphInfo->sheetWidth;
 			tex->height = glyphInfo->sheetHeight;
-			tex->param = font.magFilter | font.minFilter | GPU_TEXTURE_WRAP_S(GPU_CLAMP_TO_BORDER) |
-						 GPU_TEXTURE_WRAP_T(GPU_CLAMP_TO_BORDER);
+			tex->param = GPU_TEXTURE_MAG_FILTER(GPU_LINEAR) | GPU_TEXTURE_MIN_FILTER(GPU_LINEAR)
+				| GPU_TEXTURE_WRAP_S(GPU_CLAMP_TO_BORDER) | GPU_TEXTURE_WRAP_T(GPU_CLAMP_TO_BORDER);
 			tex->border = 0xFFFFFFFF;
 			tex->lodParam = 0;
 		}
@@ -206,8 +206,17 @@ void C2D_FontFree(C2D_Font font)
 
 void C2D_FontSetFilter(C2D_Font font, GPU_TEXTURE_FILTER_PARAM magFilter, GPU_TEXTURE_FILTER_PARAM minFilter)
 {
-	font.magFilter = magFilter;
-	font.minFilter = minFilter;
+	if (!font)
+		return;
+
+	TGLP_s* glyphInfo = font->cfnt->finf.tglp;
+
+	int i;
+	for (i = 0; i < glyphInfo->nSheets; i++)
+	{
+		C3D_Tex* tex = &font->glyphSheets[i];
+		C3D_TexSetFilter(tex, magFilter, minFilter);
+	}
 }
 
 int C2D_FontGlyphIndexFromCodePoint(C2D_Font font, u32 codepoint)

--- a/source/internal.h
+++ b/source/internal.h
@@ -57,8 +57,6 @@ struct C2D_Font_s
 	CFNT_s* cfnt;
 	C3D_Tex* glyphSheets;
 	float textScale;
-	GPU_TEXTURE_FILTER_PARAM minFilter;
-	GPU_TEXTURE_FILTER_PARAM magFilter;
 };
 
 static inline C2Di_Context* C2Di_GetContext(void)

--- a/source/internal.h
+++ b/source/internal.h
@@ -57,6 +57,8 @@ struct C2D_Font_s
 	CFNT_s* cfnt;
 	C3D_Tex* glyphSheets;
 	float textScale;
+	GPU_TEXTURE_FILTER_PARAM minFilter;
+	GPU_TEXTURE_FILTER_PARAM magFilter;
 };
 
 static inline C2Di_Context* C2Di_GetContext(void)


### PR DESCRIPTION
This PR adds support for `C2D_Font`s to have different filter modes. Useful for bitmap fonts, although they seem to have some issues depending on scaling used (which is expected). I tested this on a font called [VCR OSD Mono](https://www.dafont.com/vcr-osd-mono.font).

`GPU_LINEAR` filter
![image](https://user-images.githubusercontent.com/6239208/104679667-351f0d80-56bc-11eb-8674-9972a768d576.png)

`GPU_NEAREST` filter
![image](https://user-images.githubusercontent.com/6239208/104679670-38b29480-56bc-11eb-95a4-9b82b5d228d0.png)

I also thought I rebased my fork properly, so hopefully the commits shown here aren't an issue. Please let me know if it's something that I'll need to fix.