### PR TITLE
Wrong sprite center after the C2D_SpriteScale()

### DIFF
--- a/include/c2d/sprite.h
+++ b/include/c2d/sprite.h
@@ -52,7 +52,7 @@ static inline void C2D_SpriteScale(C2D_Sprite* sprite, float x, float y)
 	sprite->params.pos.w *= x;
 	sprite->params.pos.h *= y;
 	sprite->params.center.x *= x;
-	sprite->params.center.y *= x;
+	sprite->params.center.y *= y;
 }
 
 /** @brief Rotate sprite (relative)


### PR DESCRIPTION
The center of the sprite should be affected horizontally and also vertically. Not horizontally twice.