### PR TITLE
Fix wordNum off by one when TextBuf entirely full

### DIFF
--- a/source/text.c
+++ b/source/text.c
@@ -156,9 +156,6 @@ const char* C2D_TextFontParseLine(C2D_Text* text, C2D_Font font, C2D_TextBuf buf
 			units = 1;
 		} else if (code == 0 || code == '\n')
 		{
-			// If we last parsed non-whitespace, increment the word counter
-			if (!lastWasWhitespace)
-				wordNum++;
 			break;
 		}
 		p += units;
@@ -189,6 +186,11 @@ const char* C2D_TextFontParseLine(C2D_Text* text, C2D_Font font, C2D_TextBuf buf
 		}
 		text->width += glyphData.xAdvance;
 	}
+
+	// If we last parsed non-whitespace, increment the word counter
+	if (!lastWasWhitespace)
+		wordNum++;
+
 	text->end = buf->glyphCount;
 	text->width *= s_textScale;
 	text->lines = 1;


### PR DESCRIPTION
When the last word of a text is longer than the remaining capacity of the C2D_TextBuf, `text->words` == `glyph->wordNo` causing out of bounds access in the alloca'd arrays when drawing the glyphs of this word, resulting in crashes.

This PR ensures the words member of the C2D_Text has the correct value, even when the while loop exits from its condition (no remaining capacity) instead of the break on line end/string end.