### PR TITLE
Implement ADD, SUB, 1-TEX ADD and 1-TEX SUB as tint modes

### DIFF
--- a/include/c2d/base.h
+++ b/include/c2d/base.h
@@ -37,6 +37,8 @@ typedef enum
 	C2D_TintSolid, ///< Plain solid tint color
 	C2D_TintMult,  ///< Tint color multiplied by texture color
 	C2D_TintLuma,  ///< Tint color multiplied by grayscale converted texture color
+	C2D_TintAdd,  ///< Tint color added to the texture color
+	C2D_TintSub,  ///< Tint color subtracted from the texture color
 } C2D_TintMode;
 
 typedef struct

--- a/include/c2d/base.h
+++ b/include/c2d/base.h
@@ -39,6 +39,8 @@ typedef enum
 	C2D_TintLuma,  ///< Tint color multiplied by grayscale converted texture color
 	C2D_TintAdd,  ///< Tint color added to the texture color
 	C2D_TintSub,  ///< Tint color subtracted from the texture color
+	C2D_TintOneMinusAdd,  ///< 1 - Texture.rgb + tint color
+	C2D_TintOneMinusSub,  ///< 1 - Texture.rgb - tint color 
 } C2D_TintMode;
 
 typedef struct

--- a/source/base.c
+++ b/source/base.c
@@ -335,6 +335,12 @@ bool C2D_SetTintMode(C2D_TintMode mode)
 		case C2D_TintSub:
 			new_mode = C2DiF_Mode_ImageSub;
 			break;
+		case C2D_TintOneMinusAdd:
+			new_mode = C2DiF_Mode_ImageOMAdd;
+			break;
+		case C2D_TintOneMinusSub:
+			new_mode = C2DiF_Mode_ImageOMSub;
+			break;
 	}
 
 	ctx->flags = (ctx->flags &~ C2DiF_TintMode_Mask) | (new_mode << (C2DiF_TintMode_Shift - C2DiF_Mode_Shift));
@@ -721,21 +727,26 @@ void C2Di_Update(void)
 			break;
 		}
 		case C2DiF_Mode_ImageAdd:
+		case C2DiF_Mode_ImageOMAdd:
 		{
 			// Use texenv to blend the color source with the addition-tinted version of it,
 			// according to a parameter that is passed through with the help of proctex.
 			proctex = C2DiF_ProcTex_Blend;
 
 			// texenv0 = texclr + vtxcolor
+			// texenv0 = (1-texclr) + vtxcolor
 			env = C3D_GetTexEnv(0);
 			C3D_TexEnvInit(env);
-			C3D_TexEnvSrc(env, C3D_Both, GPU_TEXTURE0, GPU_PRIMARY_COLOR, GPU_PRIMARY_COLOR);
+			C3D_TexEnvSrc(env, C3D_RGB, GPU_TEXTURE0, GPU_PRIMARY_COLOR, GPU_PRIMARY_COLOR);
+			if (mode == C2DiF_Mode_ImageOMAdd){ // if OM set to ONE MINUS
+				C3D_TexEnvOpRgb(env, GPU_TEVOP_RGB_ONE_MINUS_SRC_COLOR, GPU_TEVOP_RGB_SRC_COLOR, GPU_TEVOP_RGB_ONE_MINUS_SRC_ALPHA);
+			}
 			C3D_TexEnvFunc(env, C3D_RGB, GPU_ADD);
 
 			// texenv1.rgb = mix(texclr.rgb, texenv0.rgb, vtx.blend.y);
 			env = C3D_GetTexEnv(1);
 			C3D_TexEnvInit(env);
-			C3D_TexEnvSrc(env, C3D_RGB, GPU_TEXTURE0, GPU_PREVIOUS, GPU_TEXTURE3);
+			C3D_TexEnvSrc(env, C3D_Both, GPU_TEXTURE0, GPU_PREVIOUS, GPU_TEXTURE3);
 			C3D_TexEnvOpRgb(env, GPU_TEVOP_RGB_SRC_COLOR, GPU_TEVOP_RGB_SRC_COLOR, GPU_TEVOP_RGB_ONE_MINUS_SRC_ALPHA);
 			C3D_TexEnvFunc(env, C3D_RGB, GPU_INTERPOLATE);
 
@@ -745,21 +756,26 @@ void C2Di_Update(void)
 			break;
 		}
 		case C2DiF_Mode_ImageSub:
+		case C2DiF_Mode_ImageOMSub:
 		{
 			// Use texenv to blend the color source with the subtraction-tinted version of it,
 			// according to a parameter that is passed through with the help of proctex.
 			proctex = C2DiF_ProcTex_Blend;
 
 			// texenv0 = texclr - vtxcolor
+			// texenv0 = (1-texclr) - vtxcolor
 			env = C3D_GetTexEnv(0);
 			C3D_TexEnvInit(env);
-			C3D_TexEnvSrc(env, C3D_Both, GPU_TEXTURE0, GPU_PRIMARY_COLOR, GPU_PRIMARY_COLOR);
+			C3D_TexEnvSrc(env, C3D_RGB, GPU_TEXTURE0, GPU_PRIMARY_COLOR, GPU_PRIMARY_COLOR);
+			if (mode == C2DiF_Mode_ImageOMSub){ // if OM set to ONE MINUS
+				C3D_TexEnvOpRgb(env, GPU_TEVOP_RGB_ONE_MINUS_SRC_COLOR, GPU_TEVOP_RGB_SRC_COLOR, GPU_TEVOP_RGB_ONE_MINUS_SRC_ALPHA);
+			}
 			C3D_TexEnvFunc(env, C3D_RGB, GPU_SUBTRACT);
 
 			// texenv1.rgb = mix(texclr.rgb, texenv0.rgb, vtx.blend.y);
 			env = C3D_GetTexEnv(1);
 			C3D_TexEnvInit(env);
-			C3D_TexEnvSrc(env, C3D_RGB, GPU_TEXTURE0, GPU_PREVIOUS, GPU_TEXTURE3);
+			C3D_TexEnvSrc(env, C3D_Both, GPU_TEXTURE0, GPU_PREVIOUS, GPU_TEXTURE3);
 			C3D_TexEnvOpRgb(env, GPU_TEVOP_RGB_SRC_COLOR, GPU_TEVOP_RGB_SRC_COLOR, GPU_TEVOP_RGB_ONE_MINUS_SRC_ALPHA);
 			C3D_TexEnvFunc(env, C3D_RGB, GPU_INTERPOLATE);
 

--- a/source/internal.h
+++ b/source/internal.h
@@ -57,6 +57,8 @@ enum
 	C2DiF_Mode_ImageLuma  = 5   << C2DiF_Mode_Shift,
 	C2DiF_Mode_ImageAdd   = 6   << C2DiF_Mode_Shift,
 	C2DiF_Mode_ImageSub   = 7   << C2DiF_Mode_Shift,
+	C2DiF_Mode_ImageOMAdd = 8   << C2DiF_Mode_Shift,
+	C2DiF_Mode_ImageOMSub = 9   << C2DiF_Mode_Shift,
 
 	C2DiF_ProcTex_Shift  = 12,
 	C2DiF_ProcTex_Mask   = 0xf << C2DiF_ProcTex_Shift,

--- a/source/internal.h
+++ b/source/internal.h
@@ -55,6 +55,8 @@ enum
 	C2DiF_Mode_ImageSolid = 3   << C2DiF_Mode_Shift,
 	C2DiF_Mode_ImageMult  = 4   << C2DiF_Mode_Shift,
 	C2DiF_Mode_ImageLuma  = 5   << C2DiF_Mode_Shift,
+	C2DiF_Mode_ImageAdd   = 6   << C2DiF_Mode_Shift,
+	C2DiF_Mode_ImageSub   = 7   << C2DiF_Mode_Shift,
 
 	C2DiF_ProcTex_Shift  = 12,
 	C2DiF_ProcTex_Mask   = 0xf << C2DiF_ProcTex_Shift,


### PR DESCRIPTION
Implements `C2D_TintAdd`, `C2D_TintSub`, `C2D_TintOneMinusAdd` and `C2D_TintOneMinusSub`, to increase the options for tint operations.

| Tint color|Original texture  |
| ------------- | ------------- |
| `#dd1040`|<img src="https://github.com/user-attachments/assets/9b1666f9-a577-4958-a4d5-4f63004e1fc3" height="100"> |

|                 | ADD  | SUB |
| ------------- | ------------- | ------------- |
|Normal | <img alt="C2D_TintAdd" src="https://github.com/user-attachments/assets/92ee1cd9-3965-4d78-ba74-aae82316ebad" height="100">  | <img alt="C2D_TintSub" src="https://github.com/user-attachments/assets/ceea20eb-fa40-48d3-9276-6ebd7aa03c24" width="100"> |
|1 - Texture.RGB | <img alt="C2D_TintOneMinusAdd" src="https://github.com/user-attachments/assets/4a9b7844-5662-49af-9cfd-92d51b95232d" height="100"> | <img alt="C2D_TintOneMinusSub" src="https://github.com/user-attachments/assets/4a5375f9-d599-4536-ac25-70a6261066f7" width="100"> |

The operations are:
`TEXTURE.RGB + TINT.RGB`,  `TEXTURE.RGB - TINT.RGB`, `1 - TEXTURE.RGB + TINT.RGB` and `1 - TEXTURE.RGB - TINT.RGB`
