### PR TITLE
[feat] Add break characters and handle zero-width space

### DIFF
--- a/source/text.c
+++ b/source/text.c
@@ -162,14 +162,7 @@ const char* C2D_TextFontParseLine(C2D_Text* text, C2D_Font font, C2D_TextBuf buf
 		p += units;
 
 		static const uint32_t break_chars[] = {
-			',', ':', '.', '"', '\'', '/',
-			0x3002, // 。
-			0xFF1F, // ？
-			0xFF01,	// ！
-			0x203C,	// ‼
-			0x2047,	// ⁇
-			0x2049,	// ⁉
-			0x2048,	// ⁈
+			'/', '-', '&',
 		};
 		bool found_break_char = false;
 		for (int i = 0; i < sizeof(break_chars) / sizeof(break_chars[0]); i++) {

--- a/source/text.c
+++ b/source/text.c
@@ -146,6 +146,7 @@ const char* C2D_TextFontParseLine(C2D_Text* text, C2D_Font font, C2D_TextBuf buf
 	text->width = 0.0f;
 	u32 wordNum = 0;
 	bool lastWasWhitespace = true;
+	uint32_t last_code = 0;
 	while (buf->glyphCount < buf->glyphBufSize)
 	{
 		uint32_t code;
@@ -160,9 +161,32 @@ const char* C2D_TextFontParseLine(C2D_Text* text, C2D_Font font, C2D_TextBuf buf
 		}
 		p += units;
 
+		static const uint32_t break_chars[] = {
+			',', ':', '.', '"', '\'', '/',
+			0x3002, // 。
+			0xFF1F, // ？
+			0xFF01,	// ！
+			0x203C,	// ‼
+			0x2047,	// ⁇
+			0x2049,	// ⁉
+			0x2048,	// ⁈
+		};
+		bool found_break_char = false;
+		for (int i = 0; i < sizeof(break_chars) / sizeof(break_chars[0]); i++) {
+			if (break_chars[i] == last_code) {
+				found_break_char = true;
+				break;
+			}
+		}
+		if (found_break_char && !lastWasWhitespace) {
+			wordNum++;
+			lastWasWhitespace = true;
+		}
+
 		fontGlyphPos_s glyphData;
 		C2D_FontCalcGlyphPos(font, &glyphData, C2D_FontGlyphIndexFromCodePoint(font, code), 0, 1.0f, 1.0f);
-		if (glyphData.width > 0.0f)
+		// we want to skip zero-width spaces
+		if (glyphData.width > 0.0f && code != 0x200B)
 		{
 			C2Di_Glyph* glyph = &buf->glyphs[buf->glyphCount++];
 			if (font)
@@ -184,7 +208,10 @@ const char* C2D_TextFontParseLine(C2D_Text* text, C2D_Font font, C2D_TextBuf buf
 			wordNum++;
 			lastWasWhitespace = true;
 		}
-		text->width += glyphData.xAdvance;
+		if (code != 0x200B) {
+			text->width += glyphData.xAdvance;
+		}
+		last_code = code;
 	}
 
 	// If we last parsed non-whitespace, increment the word counter


### PR DESCRIPTION
This PR adds break characters so that word-wrap can wrap at some punctuations and e.g. slash.

Furthermore it handles zero-width spaces to be where a word wrap can occur and to not render those at all.

This is tested and in use at NetPass.